### PR TITLE
Encrypt token before storing in user config

### DIFF
--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -141,7 +141,7 @@ class ConfigController extends Controller {
 			$this->config->setUserValue($this->userId, Application::APP_ID, 'login', $login);
 			$this->config->setUserValue($this->userId, Application::APP_ID, 'password', $this->crypto->encrypt($password));
 
-			$this->config->setUserValue($this->userId, Application::APP_ID, 'token', $result['token']);
+			$this->config->setUserValue($this->userId, Application::APP_ID, 'token', $this->crypto->encrypt($result['token']));
 			$this->config->setUserValue($this->userId, Application::APP_ID, 'user_name', $login);
 			$nowTs = (new DateTime())->getTimestamp();
 			if ($twoFactorCode !== null) {

--- a/lib/Service/ZimbraAPIService.php
+++ b/lib/Service/ZimbraAPIService.php
@@ -525,7 +525,7 @@ class ZimbraAPIService {
 						if ($preAuthKey) {
 							$preAuthResult = $this->preAuth($userId, $login);
 							if (isset($preAuthResult['token'])) {
-								$this->config->setUserValue($userId, Application::APP_ID, 'token', $preAuthResult['token']);
+								$this->config->setUserValue($userId, Application::APP_ID, 'token', $this->crypto->encrypt($preAuthResult['token']));
 								$tokenExpireAt = $nowTs + (int)($preAuthResult['token_lifetime'] / 1000);
 								$this->config->setUserValue($userId, Application::APP_ID, 'token_expires_at', (string)$tokenExpireAt);
 								return true;


### PR DESCRIPTION
This PR resolves issue #32 by encrypting the user token before storing it in the user config.
